### PR TITLE
Named routes

### DIFF
--- a/src/Type/Trout.purs
+++ b/src/Type/Trout.purs
@@ -8,13 +8,14 @@ module Type.Trout
        , Raw
        , Sub
        , LitSub
-       , AltE(..)
+       , Alt(..)
+       , Named
        , QueryParam
        , QueryParams
        , type (:>)
        , type (:/)
        , type (:<|>)
-       , (:<|>)
+       , type (:=)
        ) where
 
 -- | A literal path segment, matching paths where the next segment is equal
@@ -57,18 +58,15 @@ data Sub e t
 -- | `"a" :/ "b" :/ ...`.
 type LitSub (v :: Symbol) t = Sub (Lit v) t
 
--- | `AltE` respresents choice, i.e. that endpoint `a` is tried first, and if
--- | it fails, `b` is tried next. `AltE` is written infix using `:<|>` and is
--- | used to compose multiple endpoint types into a larger API or site. It is
--- | used to build up recursive structures, so `AltE a (AltE b c)` can be
--- | written `a :<|> b :<|> c`.
--- |
--- | It it also used to extract information from a type, where the information
--- | has the same structure as the type. For instance, when extracting links
--- | from an `AltE` type, you can pattern match the result using `:<|>`
--- | to access the links of `a` and `b`. That also works recursively with a
--- | pattern match like `a :<|> b :<|> c :<|> d`.
-data AltE a b = AltE a b
+-- | `Alt` represents choice, i.e. that endpoint `a` is tried first, and if
+-- | it fails, `b` is tried next. `Alt` is written infix using `:<|>` and is
+-- | used to compose multiple endpoint types into a larger API or site. Using
+-- | the infix operator, `Alt a (Alt b c)` can be written `a :<|> b :<|> c`.
+data Alt a b
+
+-- | `Named` associates some routing type `t` with a `name` symbol. This is
+-- | used to give names to combined routes in a routing type.
+data Named (name :: Symbol) t
 
 -- | Captures the first value of the query string parameter, or `Nothing`. `t`
 -- | is the type of the value. `k` is the name of the key as a `Symbol`.
@@ -80,5 +78,5 @@ data QueryParams (k :: Symbol) t
 
 infixr 9 type Sub as :>
 infixr 9 type LitSub as :/
-infixr 8 type AltE as :<|>
-infixr 8 AltE as :<|>
+infixr 8 type Named as :=
+infixr 7 type Alt as :<|>

--- a/src/Type/Trout/Record.js
+++ b/src/Type/Trout/Record.js
@@ -1,0 +1,27 @@
+function shallowClone(r) {
+    return Object.assign(Object.create(r), r);
+}
+
+exports.unsafeGet = function (l) {
+    return function (r) {
+        return r[l];
+    };
+};
+
+exports.unsafeSet = function (l) {
+    return function (x) {
+        return function (r) {
+            var clone = shallowClone(r);
+            clone[l] = x;
+            return clone;
+        };
+    };
+};
+
+exports.unsafeDelete = function (l) {
+    return function (r) {
+        var clone = shallowClone(r);
+        delete clone[l];
+        return clone;
+    };
+};

--- a/src/Type/Trout/Record.purs
+++ b/src/Type/Trout/Record.purs
@@ -1,0 +1,61 @@
+module Type.Trout.Record (get, set, insert, delete) where
+
+import Data.Symbol (class IsSymbol, SProxy, reflectSymbol)
+
+foreign import unsafeGet
+  :: forall r a
+   . String
+  -> Record r
+  -> a
+
+get
+  :: forall r r' l a
+   . IsSymbol l
+  => RowCons l a r' r
+  => SProxy l
+  -> Record r
+  -> a
+get l = unsafeGet (reflectSymbol l)
+
+foreign import unsafeSet
+  :: forall r1 r2 a
+   . String
+  -> a
+  -> Record r1
+  -> Record r2
+
+set
+  :: forall r1 r2 r l a b
+   . IsSymbol l
+  => RowCons l a r r1
+  => RowCons l b r r2
+  => SProxy l
+  -> b
+  -> Record r1
+  -> Record r2
+set l = unsafeSet (reflectSymbol l)
+
+insert
+  :: forall r1 r2 l a
+   . IsSymbol l
+  => RowCons l a r1 r2
+  => SProxy l
+  -> a
+  -> Record r1
+  -> Record r2
+insert l = unsafeSet (reflectSymbol l)
+
+foreign import unsafeDelete
+  :: forall r1 r2
+   . String
+  -> Record r1
+  -> Record r2
+
+delete
+  :: forall r1 r2 l a
+   . IsSymbol l
+  => RowCons l a r2 r1
+  => SProxy l
+  -> Record r1
+  -> Record r2
+delete l = unsafeDelete (reflectSymbol l)

--- a/test/Type/Trout/LinksSpec.purs
+++ b/test/Type/Trout/LinksSpec.purs
@@ -2,7 +2,6 @@ module Type.Trout.LinksSpec (spec) where
 
 import Prelude
 import Data.URI (printURI)
-import Type.Trout ((:<|>))
 import Type.Trout.Links (linksTo)
 import Type.Trout.TestSite (UserID(..), testSite)
 import Test.Spec (Spec, describe, it)
@@ -12,21 +11,20 @@ spec :: forall e. Spec e Unit
 spec = do
   describe "Hyper.Routing.Links" $
     describe "linksTo" $
-
       case linksTo testSite of
-        (homeUri :<|> userLinks :<|> wikiUri :<|> aboutUri) -> do
+        { home, users, wiki, about } -> do
 
           it "returns link for Lit" $
-            printURI homeUri `shouldEqual` "/"
+            printURI home `shouldEqual` "/"
 
           it "returns link for nested routes" $
-            case userLinks (UserID "owi") of
-              (profileUri :<|> friendsUri) -> do
-                  printURI profileUri `shouldEqual` "/users/owi/profile"
-                  printURI friendsUri `shouldEqual` "/users/owi/friends"
+            case users.user (UserID "owi") of
+              { profile, friends } -> do
+                  printURI profile `shouldEqual` "/users/owi/profile"
+                  printURI friends `shouldEqual` "/users/owi/friends"
 
           it "returns link for CaptureAll" $
-            printURI (wikiUri ["foo", "bar", "baz.txt"]) `shouldEqual` "/wiki/foo/bar/baz.txt"
+            printURI (wiki ["foo", "bar", "baz.txt"]) `shouldEqual` "/wiki/foo/bar/baz.txt"
 
           it "returns link for Raw" $
-            printURI aboutUri `shouldEqual` "/about"
+            printURI about `shouldEqual` "/about"


### PR DESCRIPTION
Adds named routes, in the form `"name" := <routing-type>`. When combining routes with `:<|>`, each route must be named.

Slightly annoying is that there's often a duplication between the route name and the (first) literal segment, e.g. `"people" := "people" :/ ...`. I'm not, however, sure that it would be wise to combine those concepts. If we would consider each literal segment a name, a routing type `"foo" :/ "bar" :/ "baz" :/ ...` would require nested records for the handlers, e.g. `{ foo: { bar: { baz: ... } } }`. Also, root resources would be strange to shoehorn into this concept. What would be the name of a single root-level resource?

Had it worked with real record types in the routing types, which I haven't figured out how to do yet, it would at least be a bit more clear what are names, and what are literal segments.

@rightfold Any thoughts?