### PR TITLE
Updates for PureScript 0.13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /generated-docs/
 /.psc*
 /.psa*
+/.spago

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,11 @@ env:
   - PATH=$HOME/purescript:$PATH
 
 install:
-- wget -O $HOME/purescript.tar.gz https://github.com/purescript/purescript/releases/download/v0.12.3/linux64.tar.gz
+- wget -O $HOME/purescript.tar.gz https://github.com/purescript/purescript/releases/download/v0.13.0/linux64.tar.gz
 - tar -xvf $HOME/purescript.tar.gz -C $HOME/
 - chmod a+x $HOME/purescript
-- npm install -g bower pulp@12.3.1
+- npm install -g bower pulp@13.0.0 spago@0.8.3
+- spago install
 - bower install
 
 script:
@@ -19,9 +20,7 @@ script:
 - if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then export VERSION=pull-request-job-$TRAVIS_JOB_NUMBER;
   fi
 - if [[ "$TRAVIS_TAG" != "" ]]; then export VERSION=$TRAVIS_TAG; fi
-- travis_wait pulp build
-- travis_wait pulp test
-
-cache:
-  directories:
-  - output
+- spago build
+- spago test
+- rm -rf .spago output
+- pulp build

--- a/bower.json
+++ b/bower.json
@@ -12,16 +12,17 @@
     "output"
   ],
   "dependencies": {
-    "purescript-prelude": "^4.1.0",
-    "purescript-uri": "^6.1.0",
+    "purescript-prelude": "^4.1.1",
+    "purescript-uri": "^7.0.0",
     "purescript-media-types": "^4.0.1",
-    "purescript-argonaut": "^5.0.0",
-    "purescript-smolder": "^11.0.1"
+    "purescript-argonaut": "^6.0.0",
+    "purescript-smolder": "^12.0.0"
   },
   "devDependencies": {
-    "purescript-console": "^4.2.0",
-    "purescript-psci-support": "^4.0.0",
-    "purescript-spec": "^3.1.0",
-    "purescript-spec-discovery": "^3.1.0"
+    "purescript-spec": "^4.0.0",
+    "purescript-spec-discovery": "^4.0.0"
+  },
+  "resolutions": {
+    "purescript-spec": "^4.0.0"
   }
 }

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,0 +1,11 @@
+let mkPackage =
+      https://raw.githubusercontent.com/purescript/package-sets/psc-0.13.0-20190626/src/mkPackage.dhall sha256:0b197efa1d397ace6eb46b243ff2d73a3da5638d8d0ac8473e8e4a8fc528cf57
+
+let upstream =
+      https://raw.githubusercontent.com/purescript/package-sets/psc-0.13.0-20190626/src/packages.dhall sha256:9905f07c9c3bd62fb3205e2108515811a89d55cff24f4341652f61ddacfcf148
+
+let overrides = {=}
+
+let additions = {=}
+
+in  upstream // overrides // additions

--- a/spago.dhall
+++ b/spago.dhall
@@ -1,0 +1,7 @@
+{ name =
+    "purescript-trout"
+, dependencies =
+    [ "argonaut", "media-types", "prelude", "smolder", "spec", "spec-discovery", "uri" ]
+, packages =
+    ./packages.dhall
+}

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -2,9 +2,10 @@ module Test.Main where
 
 import Prelude
 import Effect (Effect)
+import Effect.Aff (launchAff_)
 import Test.Spec.Discovery (discover)
 import Test.Spec.Reporter.Console (consoleReporter)
-import Test.Spec.Runner (run)
+import Test.Spec.Runner (runSpec)
 
 main :: Effect Unit
-main = discover "Type\\.Trout\\..*Spec" >>= run [consoleReporter]
+main = discover "Type\\.Trout\\..*Spec" >>= runSpec [consoleReporter] >>> launchAff_


### PR DESCRIPTION
This needs to wait on three items:
* ~~New package-sets tag that includes purescript-uri, which I added in [purescript/package-sets#351](https://github.com/purescript/package-sets/pull/351)~~ done
* ~~Release version for purescript-spec v4 (currently v4.0.0-rc1)~~ done
* ~~Release version for purescript-smolder that includes [purescript-smolder#47](https://github.com/bodil/purescript-smolder/pull/47)~~ done