### PR TITLE
Spago package name

### DIFF
--- a/spago.dhall
+++ b/spago.dhall
@@ -1,5 +1,5 @@
 { name =
-    "purescript-trout"
+    "trout"
 , dependencies =
     [ "argonaut", "media-types", "prelude", "smolder", "spec", "spec-discovery", "uri" ]
 , packages =


### PR DESCRIPTION
Just dropping the redundant _purescript-_ prefix for now to remove a bit of unnecessary noise. To my knowledge, the name in spago.dhall serves no purpose at present.