### PR TITLE
Add Header combinator.

### DIFF
--- a/src/Type/Trout.purs
+++ b/src/Type/Trout.purs
@@ -12,6 +12,7 @@ module Type.Trout
        , Named
        , QueryParam
        , QueryParams
+       , Header
        , ReqBody
        , type (:>)
        , type (:/)
@@ -76,6 +77,10 @@ data QueryParam (k :: Symbol) t
 -- | Captures all values of the query string parameter, or `[]`. `t` is the
 -- | type of the value. `k` is the name of the key as a `Symbol`.
 data QueryParams (k :: Symbol) t
+
+-- | Captures the value of a request header. `t` is the type of the value.
+-- | `n` is the name of the header as a `Symbol`.
+data Header (n :: Symbol) t
 
 -- | Captures the request body. The `r` parameter is the type represented by
 -- | the request body (usually some type specific to the application domain),

--- a/src/Type/Trout/Header.purs
+++ b/src/Type/Trout/Header.purs
@@ -1,0 +1,29 @@
+module Type.Trout.Header where
+
+import Data.Int as Int
+import Control.Category (identity)
+import Data.Either (Either(..))
+import Data.Maybe (Maybe(..))
+import Data.Semigroup ((<>))
+import Data.Show (show)
+
+class ToHeader x where
+  toHeader :: x -> String
+
+instance toHeaderString :: ToHeader String where
+  toHeader = identity
+
+instance toHeaderInt :: ToHeader Int where
+  toHeader = show
+
+class FromHeader x where
+  fromHeader :: String -> Either String x
+
+instance fromHeaderString :: FromHeader String where
+  fromHeader = Right
+
+instance fromHeaderInt :: FromHeader Int where
+  fromHeader s =
+    case Int.fromString s of
+      Just n -> Right n
+      Nothing -> Left ("Invalid Int: " <> s)


### PR DESCRIPTION
This adds a combinator that can be used to capture a header value, as in [Servant's API](https://haskell-servant.readthedocs.io/en/stable/tutorial/ApiType.html#request-headers).