### PR TITLE
Update for argonaut major version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,14 +15,14 @@
     "purescript-prelude": "^4.1.1",
     "purescript-uri": "^7.0.0",
     "purescript-media-types": "^4.0.1",
-    "purescript-argonaut": "^6.0.0",
-    "purescript-smolder": "^12.0.0"
+    "purescript-argonaut": "^7.0.0",
+    "purescript-smolder": "^12.3.0"
   },
   "devDependencies": {
-    "purescript-spec": "^4.0.0",
+    "purescript-spec": "^4.0.1",
     "purescript-spec-discovery": "^4.0.0"
   },
   "resolutions": {
-    "purescript-spec": "^4.0.0"
+    "purescript-spec": "^4.0.1"
   }
 }

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,10 +1,11 @@
-let mkPackage =
-      https://raw.githubusercontent.com/purescript/package-sets/psc-0.13.0-20190626/src/mkPackage.dhall sha256:0b197efa1d397ace6eb46b243ff2d73a3da5638d8d0ac8473e8e4a8fc528cf57
-
 let upstream =
-      https://raw.githubusercontent.com/purescript/package-sets/psc-0.13.0-20190626/src/packages.dhall sha256:9905f07c9c3bd62fb3205e2108515811a89d55cff24f4341652f61ddacfcf148
+      https://github.com/purescript/package-sets/releases/download/psc-0.13.8-20200615/packages.dhall sha256:5d0cfad9408c84db0a3fdcea2d708f9ed8f64297e164dc57a7cf6328706df93a
 
-let overrides = {=}
+let overrides = 
+      { argonaut = upstream.argonaut // { version = "v7.0.0" }
+      , argonaut-codecs = upstream.argonaut-codecs // { version = "v7.0.0" }
+      , argonaut-traversals = upstream.argonaut-traversals // { version = "v8.0.0" }
+      }
 
 let additions = {=}
 

--- a/spago.dhall
+++ b/spago.dhall
@@ -2,6 +2,8 @@
     "trout"
 , dependencies =
     [ "argonaut", "media-types", "prelude", "smolder", "spec", "spec-discovery", "uri" ]
+, sources =
+     [ "src/**/*.purs", "test/**/*.purs" ]
 , packages =
     ./packages.dhall
 }

--- a/src/Type/Trout/ContentType/JSON.purs
+++ b/src/Type/Trout/ContentType/JSON.purs
@@ -1,9 +1,9 @@
 module Type.Trout.ContentType.JSON where
 
 import Prelude
-import Data.Argonaut (class DecodeJson, class EncodeJson, decodeJson, encodeJson)
+import Data.Argonaut (class DecodeJson, class EncodeJson, decodeJson, encodeJson, parseJson, printJsonDecodeError)
 import Data.Argonaut.Core (stringify)
-import Data.Argonaut.Parser (jsonParser)
+import Data.Bifunctor (lmap)
 import Data.MediaType.Common (applicationJSON)
 import Data.Tuple (Tuple(..))
 import Type.Trout.ContentType
@@ -25,7 +25,7 @@ instance mimeRenderJson :: EncodeJson a => MimeRender a JSON String where
   mimeRender _ = stringify <<< encodeJson
 
 instance mimeParseJson :: DecodeJson a => MimeParse String JSON a where
-  mimeParse _ = jsonParser >=> decodeJson
+  mimeParse _ = lmap printJsonDecodeError <<< (decodeJson <=< parseJson)
 
 instance allMimeRenderJson :: EncodeJson a => AllMimeRender a JSON String where
   allMimeRender p x = pure (Tuple (getMediaType p) (mimeRender p x))


### PR DESCRIPTION
The most recent [major release of the Argonaut library](https://github.com/purescript-contrib/purescript-argonaut-codecs/releases/tag/v7.0.0) introduces typed errors, which affect the `MimeParse` instance for JSON in this library. This PR updates the library to be compatible with the latest Argonaut version both via Bower and Spago. I've verified the project installs, builds, and passes tests with both package managers.

I also noticed that the Spago file is using the old format with `mkPackage`, which no longer exists. I've removed that line, upgraded the package set, and set overrides for the Argonaut libraries.

Those overrides can be removed once the next package set is released, as tracked by this issue:
https://github.com/purescript/package-sets/issues/642

If everything looks good, would you mind making a new release with the updated code so it's compatible with the upcoming package set? That'll ensure this package stays in the set. Once the next package set is released then it can be updated in this project's `spago.dhall` file and the overrides can be removed (they won't be necessary anymore).

Sorry for the hassle! Thanks!